### PR TITLE
add version tag to release message comment

### DIFF
--- a/lib/git-version-bump.rb
+++ b/lib/git-version-bump.rb
@@ -173,7 +173,7 @@ module GitVersionBump
 
 					# Write your release notes above.  The first line should be the release name.
 					# To help you remember what's in here, the commits since your last release
-					# are listed below.
+					# are listed below. This will become v#{v}
 					#
 				EOF
 


### PR DESCRIPTION
Allows user to see the release version they are annotating notes for. 

Only included in the comment as opposed to a default title/body because not everyone wants to do it that way. The information is presented so they can reference/use it if they wish. 
