### PR TITLE
Show non-annotated tags as well when listing versions

### DIFF
--- a/lib/git-version-bump.rb
+++ b/lib/git-version-bump.rb
@@ -19,7 +19,7 @@ module GitVersionBump
 			sq_git_dir = shell_quoted_string((File.dirname(caller_file) rescue nil || Dir.pwd))
 		end
 
-		git_ver = `git -C #{sq_git_dir} describe --dirty='.1.dirty.#{Time.now.strftime("%Y%m%d.%H%M%S")}' --match='v[0-9]*.[0-9]*.*[0-9]' 2> #{DEVNULL}`.
+		git_ver = `git -C #{sq_git_dir} describe --tags --dirty='.1.dirty.#{Time.now.strftime("%Y%m%d.%H%M%S")}' --match='v[0-9]*.[0-9]*.*[0-9]' 2> #{DEVNULL}`.
 		            strip.
 		            gsub(/^v/, '').
 		            gsub('-', '.')
@@ -124,7 +124,7 @@ module GitVersionBump
 			if release_notes
 				# We need to find the tag before this one, so we can list all the commits
 				# between the two.  This is not a trivial operation.
-				prev_tag = `git describe --always`.strip.gsub(/-\d+-g[0-9a-f]+$/, '')
+				prev_tag = `git describe --tags --always`.strip.gsub(/-\d+-g[0-9a-f]+$/, '')
 
 				log_file = Tempfile.new('gvb')
 


### PR DESCRIPTION
Currently, creating a tag (such as is done through Github releases) will not be detected by git-version-bump. This is due to the fact that it is a lightweight tag and not an annotated tag. Support for lightweight tags as well as annotated tags would make this much more useful for projects using Github releases.

https://stackoverflow.com/questions/5002555/can-a-lightweight-tag-be-converted-to-an-annotated-tag
