### PR TITLE
Fix windows support

### DIFF
--- a/lib/git-version-bump.rb
+++ b/lib/git-version-bump.rb
@@ -97,11 +97,11 @@ module GitVersionBump
 		if $? == 0
 			# Yes, we're in git.
 
-			if dirty_tree?
+			if dirty_tree?(sq_git_dir)
 				return Time.now.strftime("%F")
 			else
 				# Clean tree.  Date of last commit is needed.
-				return `git -C #{sq_git_dir} show --no-show-signature --format=format:%cd --date=short`.lines.first.strip
+				return `git -C #{sq_git_dir} show --no-show-signature --format=format:%cd --date=short`.lines.first&.strip
 			end
 		else
 			if use_local_git
@@ -237,11 +237,9 @@ module GitVersionBump
 		$? == 0
 	end
 
-	def self.dirty_tree?
+	def self.dirty_tree?(sq_git_dir='.')
 		# Are we in a dirty, dirty tree?
-		system("! git diff --no-ext-diff --quiet --exit-code 2> #{DEVNULL} || ! git diff-index --cached --quiet HEAD 2> #{DEVNULL}")
-
-		$? == 0
+		!system("git -C #{sq_git_dir} diff --no-ext-diff --quiet --exit-code 2> #{DEVNULL}") || !("git -C #{sq_git_dir} diff-index --cached --quiet HEAD 2> #{DEVNULL}")
 	end
 
 	def self.caller_file

--- a/lib/git-version-bump.rb
+++ b/lib/git-version-bump.rb
@@ -249,14 +249,9 @@ module GitVersionBump
 		# within this file, we can't just look at Gem.location_of_caller, but
 		# instead we need to parse the caller stack ourselves to find which
 		# gem we're trying to version all over.
-		#
-		# Caller returns paths of the form `/path/to/file:100:in method...` on *nix
-		# and `C:\path\to\file:in method...` on Windows. Splitting on colon isn't
-		# reliable since the Windows path has a colon at the beginning, split on :num:
-		# instead since that will always be there no matter the platform.
 		Pathname(
-		  caller.
-		  map  { |l| l.split(/:\d+:/)[0] }.
+		  caller_locations.
+		  map(&:path).
 		  find { |l| l != __FILE__ }
 		).realpath.to_s rescue nil
 	end


### PR DESCRIPTION
Currently this gem fails to run on Windows due to errors involving paths. This commit corrects those problems.

In my case, the `http-parser.rb` gem was causing the failure (I was running on Windows using the Chef Omnibus installer, and that gem is a default one).

The path looked as follows:

 ```ruby
 s.require_paths = ["C:/opscode/chef-workstation/embedded/lib/ruby/gems/2.6.0/extensions/x64-mingw32/2.6.0/http_parser.rb-0.6.0",
   "lib"]```