### PR TITLE
Fix VERSION_TAG_GLOB to properly match 0-9 instead of 0, 9, and .

### DIFF
--- a/lib/git-version-bump.rb
+++ b/lib/git-version-bump.rb
@@ -5,7 +5,7 @@ require 'pathname'
 module GitVersionBump
 	class VersionUnobtainable < StandardError; end
 
-	VERSION_TAG_GLOB = 'v[0.9]*.[0-9]*.*[0-9]'
+	VERSION_TAG_GLOB = 'v[0-9]*.[0-9]*.*[0-9]'
 
 	DEVNULL = Gem.win_platform? ? "NUL" : "/dev/null"
 


### PR DESCRIPTION
Without this fix VERSION_TAG_GLOB will only match v0, or v9. In regex `.` apparently means literal dot when inside of `[]`.

Verified this with my gem failing to find version as well as on rubular.