### PR TITLE
Fix masked push errors

### DIFF
--- a/bin/git-version-bump
+++ b/bin/git-version-bump
@@ -50,6 +50,8 @@ end
 if dry_run
 	puts result
 else
-	GVB.tag_version result, release_notes, lite_tags
+	unless GVB.tag_version result, release_notes, lite_tags
+		exit 1
+	end
 	puts "Version is now #{GVB.version(true)}."
 end


### PR DESCRIPTION
In case the push of the commit or the tags fails (what is not very unlikely as it involves network communications), the program ends without errors, reporting the version was successfully bumped.

The reason is that system() method is invoked without any check of success or error. This commit takes into account this, assuming tag_version() method can fail returning false and indicating the error reason in STDOUT. The main program returns the appropriate error code when this happens.