### PR TITLE
Update git-version-bump.rb

### DIFF
--- a/lib/git-version-bump.rb
+++ b/lib/git-version-bump.rb
@@ -106,7 +106,7 @@ module GitVersionBump
 				log_file.close
 
 				pre_hash = Digest::SHA1.hexdigest(File.read(log_file.path))
-				run_command_retain_tty(["git", "config", "-e", "-f", log_file.path], "editing release notes")
+				run_command(["git", "config", "-e", "-f", log_file.path], "editing release notes", false)
 				if Digest::SHA1.hexdigest(File.read(log_file.path)) == pre_hash
 					puts "Release notes not edited; not making release"
 					log_file.unlink
@@ -198,10 +198,10 @@ module GitVersionBump
 
 	# Execute a command, specified as an array.
 	#
-	# On success, the full output of the command (stdout+stderr, interleaved) is returned.
+        # On success, the full output of the command (stdout+stderr, interleaved) is returned unless capture_output is not true.
 	# On error, a `CommandFailure` exception is raised.
 	#
-	def self.run_command(cmd, desc)
+	def self.run_command(cmd, desc, capture_output = true)
 		unless cmd.is_a?(Array)
 			raise ArgumentError, "Must pass command line arguments in an array"
 		end
@@ -214,7 +214,13 @@ module GitVersionBump
 			p :GVB_CMD, desc, cmd
 		end
 
-		out, status = Open3.capture2e({"LC_MESSAGES" => "C"}, *cmd)
+		if capture_output == true
+			out, status = Open3.capture2e({"LC_MESSAGES" => "C"}, *cmd)
+		else
+			out = '(output not captured)'
+			pid = spawn(*cmd)
+			(retpid, status) = Process.wait2 pid
+		end
 
 		if status.exitstatus != 0
 			raise CommandFailure.new("Failed while #{desc}", out, status.exitstatus)
@@ -223,32 +229,6 @@ module GitVersionBump
 		end
 	end
 	private_class_method :run_command
-
-        # Execute a command, specified as an array but retain ability to run the editor for notes.
-        #
-        # On success, control is returned.
-        # On error, a `CommandFailure` exception is raised.
-        #
-        def self.run_command_retain_tty(cmd, desc)
-                unless cmd.is_a?(Array)
-                        raise ArgumentError, "Must pass command line arguments in an array"
-                end
-
-                unless cmd.all? { |s| s.is_a?(String) }
-                        raise ArgumentError, "Command line arguments must be strings"
-                end
-
-                if debug?
-                        p :GVB_CMD, desc, cmd
-                end
-
-                pid = spawn(*cmd)
-                status = Process.wait pid
-
-                if status.exitstatus != 0
-                        raise CommandFailure.new("Failed while #{desc}", "(output not captured)", status.exitstatus)
-                end
-        end
 
 	# Execute a command, and return whether it succeeded or failed.
 	#

--- a/lib/git-version-bump.rb
+++ b/lib/git-version-bump.rb
@@ -246,7 +246,7 @@ module GitVersionBump
                 status = Process.wait pid
 
                 if status.exitstatus != 0
-                        raise CommandFailure.new("Failed while #{desc}", out, status.exitstatus)
+                        raise CommandFailure.new("Failed while #{desc}", "(output not captured)", status.exitstatus)
                 end
         end
 


### PR DESCRIPTION
"bundle exec git-version-bump -n p" seems to just hang for me. This fixed it for me.

Maybe I'm doing something wrong with the tool.  But VIM would not fork until I turned this into spawn.  Tried on fedora 37 and Rocky9.   Assuming spawn retains the tty vs Open3.capture2e which seems to be hijacking it.

I don't know if others have this problem or use this.

Gem really helped me with tagging!